### PR TITLE
Use is-gif directly, instead of using image-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var ExecBuffer = require('exec-buffer');
 var gifsicle = require('gifsicle').path;
-var imageType = require('image-type');
+var isGif = require('is-gif');
 
 /**
  * gifsicle image-min plugin
@@ -15,7 +15,7 @@ module.exports = function (opts) {
     opts = opts || {};
 
     return function (file, imagemin, cb) {
-        if (imageType(file.contents) !== 'gif') {
+        if (!isGif(file.contents)) {
             return cb();
         }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "exec-buffer": "^0.1.0",
     "gifsicle": "^0.1.0",
-    "image-type": "^0.1.1"
+    "is-gif": "^1.0.0"
   },
   "devDependencies": {
     "imagemin": "^1.0.0",


### PR DESCRIPTION
[These processes](https://github.com/sindresorhus/image-type/blob/b7c53eea401f28947217c76e9a0797901e033225/index.js#L3-L14) are unnecessary for this plugin.
