### PR TITLE
feat: reduce image size removing app extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = opts => buf => {
 		return Promise.resolve(buf);
 	}
 
-	const args = ['--no-warnings'];
+	const args = ['--no-warnings', '--no-app-extensions'];
 
 	if (opts.interlaced) {
 		args.push('--interlace');


### PR DESCRIPTION
Based on https://github.com/kohler/gifsicle/issues/99
Example:
![22f9cb66-3c0f-11e7-934a-5f7bb8ecb97f](https://user-images.githubusercontent.com/4567934/28064762-866bf36e-663e-11e7-97b3-57315e08d877.gif)

Without `--no-app-extensions` (`--interlace --optimize=3`): 982875 bytes.
With `--no-app-extensions` (`--interlace --optimize=3`): 981757 bytes.

/cc @shinnn @kevva 