### PR TITLE
Include additional options from the gifsicle command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,30 @@ module.exports = (options = {}) => async input => {
 		args.push(`--colors=${options.colors}`);
 	}
 
+	if (options.lossy) {
+		args.push(`--lossy=${options.lossy}`)
+	}
+
+	if (options.colorMethod) {
+		args.push(`--color-method=${options.colorMethod}`)
+	}
+
+	if (options.ditherMethod) {
+		args.push(`--dither=${options.ditherMethod}`)
+	}
+
+	if (options.resize) {
+		args.push(`--resize=${options.resize}`)
+	}
+
+	if (options.resizeMethod) {
+		args.push(`--resize-method=${options.resizeMethod}`)
+	}
+
+	if (options.resizeColors) {
+		args.push(`--resize-colors=${options.resizeColors}`)
+	}
+
 	const {stdout} = await execa(gifsicle, args, {
 		encoding: null,
 		input

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,50 @@ Type: `number`
 
 Reduce the number of distinct colors in each output GIF to num or less. Num must be between 2 and 256.
 
+##### lossy
+
+Type: `number`\
+Default: `20`
+
+Alter image colors to shrink output file size at the cost of artifacts and noise. Lossiness determines how many artifacts are allowed; higher values can result in smaller file sizes, but cause more artifacts.
+
+##### colorMethod
+
+Type: `string`\
+Default: `diversity`
+
+Determine how a smaller colormap is chosen. `diversity`, the default, is xv(1)’s diversity algorithm, which uses a strict subset of the existing colors and generally produces good results. `blend-diversity` is a modification of this: some color values are blended from groups of existing colors. `median-cut` is the median cut algorithm described by Heckbert.
+
+##### ditherMethod
+
+Type: `string`\
+Default: `floyd-steinberg`
+
+Specify a dithering algorithm with the optional method argument. The default, `floyd-steinberg`, uses Floyd-Steinberg error diffusion. This usually looks best, but can cause animation artifacts, because dithering choices will vary from frame to frame. Gifsicle also supports ordered dithering algorithms that avoid animation artifacts. The `ro64` mode uses a large, random-looking pattern and generally produces good results. The `o3`, `o4`, and `o8` modes use smaller, more regular patterns. The `ordered` mode chooses a good ordered dithering algorithm. For special effects, try the halftone modes `halftone`, `squarehalftone`, and `diagonal`. Some modes take optional parameters using commas. The halftone modes take a cell size and a color limit: `halftone,10,3` creates 10-pixel wide halftone cells where each cell uses up to 3 colors.
+
+
+##### resize
+
+Type: `string`\
+Format: `widthxheight`
+
+Resize the output GIF to the given width and height. If width or height is an underscore `_`, that dimension is chosen so that the aspect ratio remains unchanged. 
+
+##### resizeMethod
+
+Type: `string`\
+Default: `mix`
+
+Set the method used to resize images. The `sample` method runs very quickly, but when shrinking images, it produces noisy results. The `mix` method is somewhat slower, but produces better-looking results. The default method is currently `mix`.
+
+Other methods include `sample`, `box`, `mix`, `catrom`, `mitchell`, `lanczos2`, `lanczos3`. 
+
+##### resizeColors
+
+Type: `number`
+
+Allow Gifsicle to add intermediate colors when resizing images. Normally, Gifsicle’s resize algorithms use input images’ color palettes without changes. When shrinking images with very few colors (e.g., pure black-and-white images), adding intermediate colors can improve the results.
+
 #### buffer
 
 Type: `Buffer`


### PR DESCRIPTION
I've added the following options from the gifsicle command line:

- lossy
- colorMethod
- ditherMethod
- resize
- resizeMethod
- resizeColors

readme.md has also been updated to describe the new options.