### PR TITLE
Don't throw on inputs larger than 10 MB

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = (options = {}) => async input => {
 
 	const {stdout} = await execa(gifsicle, args, {
 		encoding: null,
+		maxBuffer: Infinity,
 		input
 	});
 


### PR DESCRIPTION
I'm using imagemin-gifsicle with gulp-imagemin, and I encountered a problem when imagemin-gifsicle processes files bigger than 10mb:

```
❯ gulp gif
[17:17:24] Requiring external module @babel/register
[17:17:51] Using gulpfile ~/code/web/web-template/gulpfile.babel.js
[17:17:51] Starting 'gif'...
[17:18:18] stdout maxBuffer exceeded Image Min error [Function: done]
[17:18:18] gulp-imagemin: Minified 0 images
[17:18:18] Finished 'gif' after 27 s
```

I looked into source and found index.js are using execa, it sets [default maxBuffer to 10MB](https://github.com/sindresorhus/execa#maxbuffer).

This pull request sets execa options same as [imagemin-mozjpeg](https://github.com/imagemin/imagemin-mozjpeg/commit/722826f31c0a1b064da6e92749b3823ff66fff5c#diff-168726dbe96b3ce427e7fedce31bb0bcR82), to prevent maxBuffer exceeding.