### PR TITLE
Use native ESM and update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,64 +1,26 @@
 name: test
-
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-
+  - push
+  - pull_request
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-
+  test:
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x]
-
+        node-version:
+          - 12
+          - 14
+          - 16
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
-
-  macos:
-    runs-on: macos-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
-
-  windows:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-'use strict';
-const execa = require('execa');
-const gifsicle = require('gifsicle');
-const isGif = require('is-gif');
+import {Buffer} from 'node:buffer';
+import {execa} from 'execa';
+import gifsicle from 'gifsicle';
+import isGif from 'is-gif';
 
-module.exports = (options = {}) => async input => {
+const main = (options = {}) => async input => {
 	if (!Buffer.isBuffer(input)) {
 		throw new TypeError(`Expected \`input\` to be of type \`Buffer\` but received type \`${typeof input}\``);
 	}
@@ -28,9 +28,11 @@ module.exports = (options = {}) => async input => {
 
 	const {stdout} = await execa(gifsicle, args, {
 		encoding: null,
-		maxBuffer: Infinity,
-		input
+		maxBuffer: Number.POSITIVE_INFINITY,
+		input,
 	});
 
 	return stdout;
 };
+
+export default main;

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
 	"description": "Imagemin plugin for Gifsicle",
 	"license": "MIT",
 	"repository": "imagemin/imagemin-gifsicle",
+	"type": "module",
 	"funding": "https://github.com/imagemin/imagemin-gifsicle?sponsor=1",
 	"engines": {
-		"node": ">=10"
+		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -26,12 +27,12 @@
 		"optimize"
 	],
 	"dependencies": {
-		"execa": "^4.0.0",
-		"gifsicle": "^5.0.0",
-		"is-gif": "^3.0.0"
+		"execa": "^6.0.0",
+		"gifsicle": "^6.1.0",
+		"is-gif": "^4.0.1"
 	},
 	"devDependencies": {
-		"ava": "^3.8.0",
-		"xo": "^0.30.0"
+		"ava": "^3.15.0",
+		"xo": "^0.46.4"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# imagemin-gifsicle ![GitHub Actions Status](https://github.com/imagemin/imagemin-gifsicle/workflows/test/badge.svg?branch=master)
+# imagemin-gifsicle ![GitHub Actions Status](https://github.com/imagemin/imagemin-gifsicle/workflows/test/badge.svg?branch=main)
 
 > Imagemin plugin for [Gifsicle](https://www.lcdf.org/gifsicle/)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# imagemin-gifsicle
+# imagemin-gifsicle ![GitHub Actions Status](https://github.com/imagemin/imagemin-gifsicle/workflows/test/badge.svg?branch=master)
 
 > Imagemin plugin for [Gifsicle](https://www.lcdf.org/gifsicle/)
 
@@ -11,8 +11,8 @@ $ npm install imagemin-gifsicle
 ## Usage
 
 ```js
-const imagemin = require('imagemin');
-const imageminGifsicle = require('imagemin-gifsicle');
+import imagemin from 'imagemin';
+import imageminGifsicle from 'imagemin-gifsicle';
 
 (async () => {
 	await imagemin(['images/*.gif'], {

--- a/test.js
+++ b/test.js
@@ -1,14 +1,12 @@
-const {promisify} = require('util');
-const fs = require('fs');
-const path = require('path');
-const isGif = require('is-gif');
-const test = require('ava');
-const imageminGifsicle = require('.');
-
-const readFile = promisify(fs.readFile);
+import {Buffer} from 'node:buffer';
+import {promises as fs} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import isGif from 'is-gif';
+import test from 'ava';
+import imageminGifsicle from './index.js';
 
 test('Buffer', async t => {
-	const buf = await readFile(path.join(__dirname, 'fixture.gif'));
+	const buf = await fs.readFile(fileURLToPath(new URL('fixture.gif', import.meta.url)));
 	const data = await imageminGifsicle()(buf);
 
 	t.true(data.length < buf.length);

--- a/test.js
+++ b/test.js
@@ -1,12 +1,11 @@
 import {Buffer} from 'node:buffer';
 import {promises as fs} from 'node:fs';
-import {fileURLToPath} from 'node:url';
 import isGif from 'is-gif';
 import test from 'ava';
 import imageminGifsicle from './index.js';
 
 test('Buffer', async t => {
-	const buf = await fs.readFile(fileURLToPath(new URL('fixture.gif', import.meta.url)));
+	const buf = await fs.readFile(new URL('fixture.gif', import.meta.url));
 	const data = await imageminGifsicle()(buf);
 
 	t.true(data.length < buf.length);


### PR DESCRIPTION
This PR will:

* Update package to be ESM only
* Update `gifsicle` to `^6.0.0` (this probably closes https://github.com/imagemin/imagemin-gifsicle/pull/47)
* Add meta tweaks